### PR TITLE
fix `nice` syntax for *nix OSes

### DIFF
--- a/scripts/Thumbnailer_Worker.lua
+++ b/scripts/Thumbnailer_Worker.lua
@@ -243,7 +243,7 @@ local function add_nice(args)
 	if OPERATING_SYSTEM == OS_MAC then
 		add_args(args, worker_options.exec_path .. 'gnice', '-19')
 	elseif OPERATING_SYSTEM == OS_NIX then
-		add_args(args, worker_options.exec_path .. 'nice', '19')
+		add_args(args, worker_options.exec_path .. 'nice', '-n', '19')
 	elseif OPERATING_SYSTEM == OS_WIN then
 		-- unimplemented
 	end


### PR DESCRIPTION
GNU coreutils `nice` (default on many Linux distributions) requires the nice value to be specified with the `-n` argument, i.e. `nice -n 19`. This argument is also required on Busybox `nice` and BSD `nice`, so it's more portable than just `nice 19`, which fails with the error `nice: ‘19’: No such file or directory`.